### PR TITLE
Make plugin distributable

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A tiny Neovim plugin to insert `console.log({ word })` for the word under the cu
 {
   "RakshithNM/logdebug.nvim",
   config = function()
-    require("logger").setup()
+    require("logdebug").setup()
   end
 }
 ```
@@ -18,9 +18,9 @@ A tiny Neovim plugin to insert `console.log({ word })` for the word under the cu
 
 ```lua
 use {
-  "yourgithub/console-log.nvim",
+  "RakshithNM/logdebug.nvim",
   config = function()
-    require("console_log").setup()
+    require("logdebug").setup()
   end
 }
 ```
@@ -28,8 +28,7 @@ use {
 ### Configuration(optional)
 
 ```lua
-require("console_log").setup({
+require("logdebug").setup({
   keymap = "<leader>lg" -- default is <leader>cl
 })
-```
 ```

--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,1 @@
+return require("logdebug")

--- a/lua/logdebug/init.lua
+++ b/lua/logdebug/init.lua
@@ -9,7 +9,7 @@ end
 
 function M.setup(opts)
 	opts = opts or {}
-	local keymap = opts.keymap or "<leader>wl"
+	local keymap = opts.keymap or "<leader>cl"
 
 	vim.keymap.set("n", keymap, M.log_word_under_cursor, { desc = "Console log word under cursor" })
 end


### PR DESCRIPTION
## Summary
- rename module to `logdebug`
- update default keymap and init file
- fix README instructions

## Testing
- `luacheck .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885c5ea98a08330822a030a54d0c9c5