### PR TITLE
Add logging above/below cursor

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ use {
 
 ```lua
 require("logdebug").setup({
-  keymap = "<leader>lg" -- default is <leader>cl
+  keymap_below = "<leader>lg", -- default is <leader>wl
+  -- keymap_above = "<leader>lh" -- map to insert above cursor
 })
 ```

--- a/lua/logdebug/init.lua
+++ b/lua/logdebug/init.lua
@@ -1,17 +1,33 @@
 local M = {}
 
-function M.log_word_under_cursor()
+local function insert_log_line(below)
 	local word = vim.fn.expand("<cword>")
 	local line_num = vim.fn.line(".")
 	local log_line = string.format("console.log({ %s });", word)
+	if below then
 	vim.fn.append(line_num, log_line)
+	else
+	vim.fn.append(line_num - 1, log_line)
+	end
+end
+
+function M.log_word_below_cursor()
+	insert_log_line(true)
+end
+
+function M.log_word_above_cursor()
+	insert_log_line(false)
 end
 
 function M.setup(opts)
 	opts = opts or {}
-	local keymap = opts.keymap or "<leader>wl"
-
-	vim.keymap.set("n", keymap, M.log_word_under_cursor, { desc = "Console log word under cursor" })
+	local keymap_below = opts.keymap_below or "<leader>wl"
+	local keymap_above = opts.keymap_above
+	
+	vim.keymap.set("n", keymap_below, M.log_word_below_cursor, { desc = "Console log word below cursor" })
+	if keymap_above then
+	vim.keymap.set("n", keymap_above, M.log_word_above_cursor, { desc = "Console log word above cursor" })
+	end
 end
 
 return M


### PR DESCRIPTION
## Summary
- add `keymap_below` and optional `keymap_above`
- support inserting logs above or below the cursor
- update README with new configuration

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_6885cf390050833081fe5e9cd96834e7