### PR TITLE
Add console log removal feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,5 +31,6 @@ use {
 require("logdebug").setup({
   keymap_below = "<leader>lg", -- default is <leader>wl
   -- keymap_above = "<leader>lh" -- map to insert above cursor
+  -- keymap_remove = "<leader>ld" -- remove all console logs
 })
 ```

--- a/lua/logdebug/init.lua
+++ b/lua/logdebug/init.lua
@@ -19,14 +19,27 @@ function M.log_word_above_cursor()
 	insert_log_line(false)
 end
 
+function M.remove_all_logs()
+	local bufnr = vim.api.nvim_get_current_buf()
+	for i = vim.api.nvim_buf_line_count(bufnr), 1, -1 do
+		local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1]
+		if line:match('^%s*console%.log%(') then
+			vim.api.nvim_buf_set_lines(bufnr, i - 1, i, false, {})
+		end
+	end
+end
 function M.setup(opts)
 	opts = opts or {}
 	local keymap_below = opts.keymap_below or "<leader>wl"
 	local keymap_above = opts.keymap_above
+	local keymap_remove = opts.keymap_remove or "<leader>wd"
 	
 	vim.keymap.set("n", keymap_below, M.log_word_below_cursor, { desc = "Console log word below cursor" })
 	if keymap_above then
 	vim.keymap.set("n", keymap_above, M.log_word_above_cursor, { desc = "Console log word above cursor" })
+	end
+	if keymap_remove then
+		vim.keymap.set("n", keymap_remove, M.remove_all_logs, { desc = "Remove console logs" })
 	end
 end
 


### PR DESCRIPTION
## Summary
- add `remove_all_logs` to strip `console.log` lines
- map new action via `keymap_remove` with default `<leader>wd`
- document new option in README

## Testing
- `lua` not available, so no tests run

------
https://chatgpt.com/codex/tasks/task_e_6885d1f71cd88330bdbf0cb8919b00cd