### PR TITLE
Switch removal to commenting

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,6 @@ require("logdebug").setup({
   keymap_below = "<leader>lg", -- default is <leader>wl
   -- keymap_above = "<leader>lh" -- map to insert above cursor
   -- keymap_remove = "<leader>ld" -- remove all console logs
+  -- keymap_comment = "<leader>lc" -- comment out all console logs
 })
 ```

--- a/lua/logdebug/init.lua
+++ b/lua/logdebug/init.lua
@@ -20,27 +20,43 @@ function M.log_word_above_cursor()
 end
 
 function M.remove_all_logs()
-	local bufnr = vim.api.nvim_get_current_buf()
-	for i = vim.api.nvim_buf_line_count(bufnr), 1, -1 do
-		local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1]
-		if line:match('^%s*console%.log%(') then
-			vim.api.nvim_buf_set_lines(bufnr, i - 1, i, false, {})
-		end
-	end
+        local bufnr = vim.api.nvim_get_current_buf()
+        for i = vim.api.nvim_buf_line_count(bufnr), 1, -1 do
+                local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1]
+                if line:match('^%s*console%.log%(') then
+                        vim.api.nvim_buf_set_lines(bufnr, i - 1, i, false, {})
+                end
+        end
+end
+
+function M.comment_all_logs()
+        local bufnr = vim.api.nvim_get_current_buf()
+        for i = vim.api.nvim_buf_line_count(bufnr), 1, -1 do
+                local line = vim.api.nvim_buf_get_lines(bufnr, i - 1, i, false)[1]
+                if line:match('^%s*console%.log%(') then
+                        local indent = line:match('^%s*') or ""
+                        local uncommented = line:sub(#indent + 1)
+                        vim.api.nvim_buf_set_lines(bufnr, i - 1, i, false, { indent .. "//" .. uncommented })
+                end
+        end
 end
 function M.setup(opts)
-	opts = opts or {}
-	local keymap_below = opts.keymap_below or "<leader>wl"
-	local keymap_above = opts.keymap_above
-	local keymap_remove = opts.keymap_remove or "<leader>wd"
+        opts = opts or {}
+        local keymap_below = opts.keymap_below or "<leader>wl"
+        local keymap_above = opts.keymap_above
+        local keymap_remove = opts.keymap_remove or "<leader>wd"
+        local keymap_comment = opts.keymap_comment or "<leader>wc"
 	
 	vim.keymap.set("n", keymap_below, M.log_word_below_cursor, { desc = "Console log word below cursor" })
-	if keymap_above then
-	vim.keymap.set("n", keymap_above, M.log_word_above_cursor, { desc = "Console log word above cursor" })
-	end
-	if keymap_remove then
-		vim.keymap.set("n", keymap_remove, M.remove_all_logs, { desc = "Remove console logs" })
-	end
+        if keymap_above then
+        vim.keymap.set("n", keymap_above, M.log_word_above_cursor, { desc = "Console log word above cursor" })
+        end
+        if keymap_remove then
+                vim.keymap.set("n", keymap_remove, M.remove_all_logs, { desc = "Remove console logs" })
+        end
+        if keymap_comment then
+                vim.keymap.set("n", keymap_comment, M.comment_all_logs, { desc = "Comment out console logs" })
+        end
 end
 
 return M


### PR DESCRIPTION
## Summary
- add new keymap for commenting console logs instead of deleting
- keep existing delete behavior
- update README with new keymap example

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6885d5d5069c83308728191a2665950d