### PR TITLE
Add verbosity toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # logdebug.nvim
-A tiny Neovim plugin to insert `console.log({ word })` for the word under the cursor — perfect for debugging!
+A tiny Neovim plugin to insert `console` statements for the word under the cursor — perfect for debugging!
+Toggle between `log`, `info`, `warn`, and `error` verbosity levels.
 
 ## 🔧 Installation
 
@@ -33,5 +34,6 @@ require("logdebug").setup({
   -- keymap_above = "<leader>lh" -- map to insert above cursor
   -- keymap_remove = "<leader>ld" -- remove all console logs
   -- keymap_comment = "<leader>lc" -- comment out all console logs
+  -- keymap_toggle = "<leader>wv" -- toggle log verbosity
 })
 ```


### PR DESCRIPTION
## Summary
- toggle between `console.log`, `console.info`, `console.warn`, and `console.error`
- document verbosity toggle usage

## Testing
- `luacheck lua/logdebug/init.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6885d8c5ec408330886ff486d56a3aee