### PR TITLE
Update README and add help docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # logdebug.nvim
-A tiny Neovim plugin to insert `console` statements for the word under the cursor — perfect for debugging!
-Toggle between `log`, `info`, `warn`, and `error` verbosity levels.
+A tiny Neovim plugin to quickly insert `console` statements for the word under the cursor.
+It includes helpers for removing or commenting out these statements and can toggle
+between `log`, `info`, `warn` and `error` verbosity levels.
+
+## ✨ Features
+- Insert a console log above or below the current line
+- Remove all console logs in the buffer (including commented ones)
+- Comment out every console log in the buffer
+- Toggle the verbosity level used when inserting logs
+- Optionally restrict mappings to specific filetypes
 
 ## 🔧 Installation
 
 ### Lazy.nvim
-
 ```lua
 {
   "RakshithNM/logdebug.nvim",
@@ -16,7 +23,6 @@ Toggle between `log`, `info`, `warn`, and `error` verbosity levels.
 ```
 
 ### Packer
-
 ```lua
 use {
   "RakshithNM/logdebug.nvim",
@@ -26,17 +32,28 @@ use {
 }
 ```
 
-### Configuration(optional)
-
+## ⚙️ Configuration (optional)
 ```lua
 require("logdebug").setup({
-  keymap_below = "<leader>wlb", -- word log below
-  keymap_above = "<leader>wla" -- word log above
-  keymap_remove = "<leader>dl" -- delete all console logs, including commented ones
-  keymap_comment = "<leader>kl" -- Komment out all console logs
+  keymap_below = "<leader>wla", -- log word below cursor
+  keymap_above = "<leader>wlb", -- log word above cursor
+  keymap_remove = "<leader>dl", -- delete all console logs (commented ones too)
+  keymap_comment = "<leader>kl", -- comment out all console logs
   keymap_toggle = "<leader>tll", -- toggle log level
   filetypes = { "javascript", "typescript", "javascriptreact", "typescriptreact", "vue" } -- optional filetype filter
 })
 ```
+Provide a list of filetypes to `filetypes` to only enable the plugin's keymaps in
+those buffers. When omitted, the keymaps are created globally.
 
-Provide a list of filetypes to `filetypes` to only enable the plugin's keymaps in those buffers. When omitted, the keymaps are created globally.
+## 📖 Usage
+After setup the default mappings are:
+```
+<leader>wla  log word below cursor
+<leader>wlb  log word above cursor
+<leader>dl   remove all console logs
+<leader>kl   comment out console logs
+<leader>tll  toggle log level
+```
+Invoke `:help logdebug` inside Neovim to read the full documentation.
+

--- a/doc/logdebug.txt
+++ b/doc/logdebug.txt
@@ -1,0 +1,39 @@
+*logdebug.txt*  Logdebug.nvim plugin documentation
+
+LOGDEBUG.NVIM                                                  *logdebug*
+
+Logdebug.nvim is a tiny Neovim plugin that helps insert `console` statements for the word under the cursor. It also provides helpers to clean up or comment out these statements and to toggle their verbosity level.
+
+==============================================================================
+MAPPINGS                                                    *logdebug-mappings*
+
+The plugin sets up mappings when `require("logdebug").setup()` is called.
+
+Default mappings:
+    <leader>wla    Insert console log below the current line
+    <leader>wlb    Insert console log above the current line
+    <leader>dl     Remove all console logs (including commented ones)
+    <leader>kl     Comment out all console logs
+    <leader>tll    Toggle log level (log/info/warn/error)
+
+==============================================================================
+SETUP                                                          *logdebug-setup*
+
+`require("logdebug").setup({opts})` takes the following optional keys:
+    keymap_below   Mapping to insert log below     (default "<leader>wla")
+    keymap_above   Mapping to insert log above     (default "<leader>wlb")
+    keymap_remove  Mapping to remove logs          (default "<leader>dl")
+    keymap_comment Mapping to comment logs         (default "<leader>kl")
+    keymap_toggle  Mapping to toggle log level     (default "<leader>tll")
+    filetypes      List of filetypes to activate the plugin for
+
+When `filetypes` is provided, mappings are only created for buffers whose `'filetype'` matches one in the list. Otherwise they are global.
+
+==============================================================================
+USAGE                                                           *logdebug-usage*
+
+Use the mappings above (or your customised ones) to insert, remove or comment console statements. The log level cycles through `log`, `info`, `warn` and `error` each time the toggle mapping is invoked.
+
+==============================================================================
+
+vim:tw=78:ft=help:norl


### PR DESCRIPTION
## Summary
- document plugin features in README
- provide installation, configuration, usage, and help info
- add `doc/logdebug.txt` so the README can be read with `:help`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6885e3001ce48330ae6b6ef05af09ee7